### PR TITLE
Property for tab navigation

### DIFF
--- a/script/engine.js
+++ b/script/engine.js
@@ -6,6 +6,7 @@
 		MAX_STORE: 99999999999999,
 		SAVE_DISPLAY: 30 * 1000,
 		GAME_OVER: false,
+		tabNavigation: true,
 
 		//object event types
 		topics: {},
@@ -634,27 +635,31 @@
 						break;
 					case 37: // Left
 					case 65:
-						if(Engine.activeModule == Ship && Path.tab)
-							Engine.travelTo(Path);
-						else if(Engine.activeModule == Path && Outside.tab){
-							Engine.activeModule.scrollSidebar('left', true);
-							Engine.travelTo(Outside);
-						}else if(Engine.activeModule == Outside && Room.tab){
-							Engine.activeModule.scrollSidebar('left', true);
-							Engine.travelTo(Room);
+						if(Engine.tabNavigation){
+							if(Engine.activeModule == Ship && Path.tab)
+								Engine.travelTo(Path);
+							else if(Engine.activeModule == Path && Outside.tab){
+								Engine.activeModule.scrollSidebar('left', true);
+								Engine.travelTo(Outside);
+							}else if(Engine.activeModule == Outside && Room.tab){
+								Engine.activeModule.scrollSidebar('left', true);
+								Engine.travelTo(Room);
+							}
 						}
 						Engine.log('left');
 						break;
 					case 39: // Right
 					case 68:
-						if(Engine.activeModule == Room && Outside.tab)
-							Engine.travelTo(Outside);
-						else if(Engine.activeModule == Outside && Path.tab){
-							Engine.activeModule.scrollSidebar('right', true);
-							Engine.travelTo(Path);
-						}else if(Engine.activeModule == Path && Ship.tab){
-							Engine.activeModule.scrollSidebar('right', true);
-							Engine.travelTo(Ship);
+						if(Engine.tabNavigation){
+							if(Engine.activeModule == Room && Outside.tab)
+								Engine.travelTo(Outside);
+							else if(Engine.activeModule == Outside && Path.tab){
+								Engine.activeModule.scrollSidebar('right', true);
+								Engine.travelTo(Path);
+							}else if(Engine.activeModule == Path && Ship.tab){
+								Engine.activeModule.scrollSidebar('right', true);
+								Engine.travelTo(Ship);
+							}
 						}
 						Engine.log('right');
 						break;

--- a/script/engine.js
+++ b/script/engine.js
@@ -6,7 +6,6 @@
 		MAX_STORE: 99999999999999,
 		SAVE_DISPLAY: 30 * 1000,
 		GAME_OVER: false,
-		tabNavigation: true,
 
 		//object event types
 		topics: {},
@@ -600,6 +599,14 @@
 			//return (num > 0 ? "+" : "") + num + " per " + delay + "s";
 		},
 
+		tabNavigation: true,
+
+		restoreNavigation: function(){
+			setTimeout(function(){
+				Engine.tabNavigation = true;
+			},100);
+		},
+	
 		keyDown: function(e) {
 			e = e || window.event;
 			if(!Engine.keyPressed && !Engine.keyLock) {

--- a/script/world.js
+++ b/script/world.js
@@ -801,12 +801,6 @@ var World = {
 		map.html(mapString);
 	},
 	
-	restoreNavigation: function(){
-		setTimeout(function(){
-			Engine.tabNavigation = true;
-		},100);
-	},
-	
 	die: function() {
 		if(!World.dead) {
 			World.dead = true;

--- a/script/world.js
+++ b/script/world.js
@@ -801,6 +801,12 @@ var World = {
 		map.html(mapString);
 	},
 	
+	restoreNavigation: function(){
+		setTimeout(function(){
+			Engine.tabNavigation = true;
+		},100);
+	},
+	
 	die: function() {
 		if(!World.dead) {
 			World.dead = true;
@@ -823,6 +829,7 @@ var World = {
 					$('#outerSlider').animate({opacity:'1'}, 600, 'linear');
 					Button.cooldown($('#embarkButton'));
 					Engine.keyLock = false;
+					Engine.restoreNavigation();
 				}, 2000, true);
 			});
 		}
@@ -865,6 +872,7 @@ var World = {
 		$('#outerSlider').animate({left: '0px'}, 300);
 		Engine.activeModule = Path;
 		Path.onArrival();
+		Engine.restoreNavigation();
 	},
 	
 	leaveItAtHome: function(thing) {


### PR DESCRIPTION
Added Engine.tabNavigation property. When true, it enables keyboard navigation to/from tabs. It is disabled on world and enabled some milliseconds after Path.onArrival(), so that when player returns s/he finds him/herself on Path tab instead of navigating.
