### PR TITLE
DIV tooltip

### DIFF
--- a/css/dark.css
+++ b/css/dark.css
@@ -26,7 +26,7 @@ div#saveNotify {
 	background-color: #272823;
 }
 
-div.tooltip {
+*.tooltip {
 	background-color: #171813;
 	border: 1px solid black;
 	box-shadow: -1px 3px 2px #111;

--- a/css/main.css
+++ b/css/main.css
@@ -365,13 +365,13 @@ div.button div.cooldown {
 	border-color: #999 transparent transparent;
 }
 
-div.button div.tooltip {
+div.button *.tooltip {
 	width: 100px;
 }
 
 /* Tooltip */
 
-div.tooltip {
+*.tooltip {
 	display: none;
 	padding: 2px 5px;
 	border: 1px solid black;
@@ -397,19 +397,19 @@ div.tooltip {
 	bottom: 20px;
 }
 
-*:hover > div.tooltip {
+*:hover > *.tooltip {
 	display: block;
 }
 
-div.tooltip:hover {
+*.tooltip:hover {
 	display: none !important;
 }
 
-.disabled:hover > div.tooltip, .button.free:hover > div.tooltip {
+.disabled:hover > *.tooltip, .button.free:hover > *.tooltip {
 	display: none;
 }
 
-#event .button.disabled:hover > div.tooltip {
+#event .button.disabled:hover > *.tooltip {
 	display: block;
 }
 

--- a/script/world.js
+++ b/script/world.js
@@ -854,7 +854,7 @@ var World = {
 							break;
 						default:
 							if(typeof World.LANDMARKS[c] != 'undefined' && (c != World.TILE.OUTPOST || !World.outpostUsed(i, j))) {
-								mapString += '<span class="landmark">' + c + '<div class="tooltip' + ttClass + '">' + World.LANDMARKS[c].label + '</div></span>';
+								mapString += '<span class="landmark">' + c + '<span class="tooltip' + ttClass + '">' + World.LANDMARKS[c].label + '</span></span>';
 							} else {
 								if(c.length > 1) {
 									c = c[0];


### PR DESCRIPTION
In HTML, DIV inside SPAN are not allowed. This replaces div.tooltip in maps with span.tooltip, fixing CSS accordingly to show tooltip as block elements.